### PR TITLE
fix(rails): use fixture_path for Rails versions < 7.1

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,18 @@ ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __d
 require "rails/test_help"
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
-  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
-  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
-  ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
-  ActiveSupport::TestCase.fixtures :all
+if Rails::VERSION::STRING >= "7.1"
+  if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+    ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+    ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+    ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
+    ActiveSupport::TestCase.fixtures :all
+  end
+else
+  if ActiveSupport::TestCase.respond_to?(:fixture_path=)
+    ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
+    ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
+    ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+    ActiveSupport::TestCase.fixtures :all
+  end
 end


### PR DESCRIPTION

The gem was generated with Rails 7.1 in mind but the fixture_paths wasn't a thing for previous versions, so, this is adding support for those Rails versions.